### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,10 @@
     "async-retry": "^1.3.1",
     "debug": "^3.1.0"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vercel/fetch-retry.git"
+  },
   "scripts": {
     "test": "jest test"
   }


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	*@zeit/fetch-retry